### PR TITLE
Add model-level secrets handling

### DIFF
--- a/.github/workflows/google.yml
+++ b/.github/workflows/google.yml
@@ -14,9 +14,13 @@ on:
   push:
     branches:
       - master
+    paths:
+      - "config/**"
   pull_request:
     branches:
       - master
+    paths:
+      - "config/**"
 
 # Environment variables available to all jobs and steps in this workflow
 env:

--- a/.github/workflows/google.yml
+++ b/.github/workflows/google.yml
@@ -21,7 +21,7 @@ on:
 # Environment variables available to all jobs and steps in this workflow
 env:
   GKE_PROJECT: ${{ secrets.GKE_PROJECT }}
-  PROJECT:  ${{ secrets.PROJECT }}
+  PROJECT: ${{ secrets.PROJECT }}
   GKE_EMAIL: ${{ secrets.GKE_EMAIL }}
   GITHUB_SHA: ${{ github.sha }}
   GKE_ZONE: us-central1-c
@@ -33,58 +33,57 @@ jobs:
     name: Setup, Build, Test, Publish
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Checkout
-      uses: actions/checkout@v2
+      - run: git fetch origin master --depth 2
 
-    - run: git fetch origin master --depth 2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.x"
 
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.x'
+      # Install pip and pytest
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install google-cloud-secret-manager
+          python -m pip install -e .
 
-    # Install pip and pytest
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -e .
+      # Setup gcloud CLI
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: "270.0.0"
+          service_account_email: ${{ secrets.GKE_EMAIL }}
+          service_account_key: ${{ secrets.GKE_KEY }}
 
-    # Setup gcloud CLI
-    - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
-      with:
-        version: '270.0.0'
-        service_account_email: ${{ secrets.GKE_EMAIL }}
-        service_account_key: ${{ secrets.GKE_KEY }}
+      # Configure docker to use the gcloud command-line tool as a credential helper
+      - run: |
+          # Set up docker to authenticate
+          # via gcloud command-line tool.
+          gcloud auth configure-docker
 
-    # Configure docker to use the gcloud command-line tool as a credential helper
-    - run: |
-        # Set up docker to authenticate
-        # via gcloud command-line tool.
-        gcloud auth configure-docker
+      # Build Docker images
+      - name: Build
+        run: |
+          cs-publish --tag $GITHUB_SHA --build
 
-    # Build Docker images
-    - name: Build
-      run: |
-        cs-publish --tag $GITHUB_SHA --build
+      # Test Docker images
+      - name: Test
+        run: |
+          cs-publish --tag $GITHUB_SHA --test
 
-    # Test Docker images
-    - name: Test
-      run: |
-        cs-publish --tag $GITHUB_SHA --test
+      # Push Docker images to Google Container Registry
+      - name: Publish
+        if: github.event_name == 'push'
+        run: |
+          cs-publish --tag $GITHUB_SHA --push --base-branch 'HEAD^'
 
-    # Push Docker images to Google Container Registry
-    - name: Publish
-      if: github.event_name == 'push'
-      run: |
-        cs-publish --tag $GITHUB_SHA --push --base-branch 'HEAD^'
-
-    # Apply updates to cluster
-    - name: Deploy
-      if: github.event_name == 'push'
-      run: |
-        gcloud container clusters get-credentials $GKE_CLUSTER --zone $GKE_ZONE --project $GKE_PROJECT
-        cs-publish --tag $GITHUB_SHA --make-config --base-branch 'HEAD^'
-        kubectl apply -f kubernetes/
-        kubectl get pods -o wide
+      # Apply updates to cluster
+      - name: Deploy
+        if: github.event_name == 'push'
+        run: |
+          gcloud container clusters get-credentials $GKE_CLUSTER --zone $GKE_ZONE --project $GKE_PROJECT
+          cs-publish --tag $GITHUB_SHA --make-config --base-branch 'HEAD^' -o - | kubectl apply -f -
+          kubectl get pods -o wide

--- a/cs_publish/secrets.py
+++ b/cs_publish/secrets.py
@@ -105,11 +105,11 @@ def main():
 
     secrets = Secrets(args.owner, args.title, args.project)
     if args.secret_name and args.secret_value:
-        print(secrets.set_secret(args.secret_name, args.secret_value))
+        secrets.set_secret(args.secret_name, args.secret_value)
     elif args.secret_name:
         print(secrets.get_secret(args.secret_name))
     elif args.delete:
-        print(secrets.delete_secret(args.delete))
+        secrets.delete_secret(args.delete)
 
     if args.list:
         print(json.dumps(secrets.list_secrets(), indent=2))

--- a/cs_publish/secrets.py
+++ b/cs_publish/secrets.py
@@ -1,0 +1,115 @@
+import argparse
+import json
+import os
+
+from cs_publish.utils import clean
+
+PROJECT = os.environ.get("PROJECT", "cs-workers-dev")
+
+
+class SecretNotFound(Exception):
+    pass
+
+
+class Secrets:
+    def __init__(self, owner, title, project):
+        self.owner = owner
+        self.title = title
+        self.project = project
+        self.safe_owner = clean(owner)
+        self.safe_title = clean(title)
+        self.client = None
+
+    def set_secret(self, name, value):
+        return self._set_secret(name, value)
+
+    def get_secret(self, name):
+        return self._get_secret(name)
+
+    def list_secrets(self):
+        return self._get_secret()
+
+    def delete_secret(self, name):
+        return self._set_secret(name, None)
+
+    def _set_secret(self, name, value):
+        secret_name = f"{self.safe_owner}_{self.safe_title}"
+
+        client = self._client()
+        try:
+            secret_val = self._get_secret()
+        except SecretNotFound:
+            secret_val = {name: value}
+            proj_parent = client.project_path(self.project)
+            client.create_secret(
+                proj_parent, secret_name, {"replication": {"automatic": {}}}
+            )
+        else:
+            if secret_val is not None:
+                secret_val[name] = value
+            else:
+                secret_val = {name: value}
+            if value is None:
+                secret_val.pop(name)
+
+        secret_bytes = json.dumps(secret_val).encode("utf-8")
+
+        secret_parent = client.secret_path(self.project, secret_name)
+
+        return client.add_secret_version(secret_parent, {"data": secret_bytes})
+
+    def _get_secret(self, name=None):
+        from google.api_core import exceptions
+
+        secret_name = f"{self.safe_owner}_{self.safe_title}"
+
+        client = self._client()
+
+        try:
+            response = client.access_secret_version(
+                f"projects/{self.project}/secrets/{secret_name}/versions/latest"
+            )
+
+            secret = json.loads(response.payload.data.decode("utf-8"))
+        except exceptions.NotFound:
+            raise SecretNotFound()
+
+        if name and name in secret:
+            return secret[name]
+        elif name:
+            return None
+        else:
+            return secret
+
+    def _client(self):
+        if self.client:
+            return self.client
+
+        from google.cloud import secretmanager
+
+        self.client = secretmanager.SecretManagerServiceClient()
+        return self.client
+
+
+def main():
+    parser = argparse.ArgumentParser(description="CLI for model secrets.")
+    parser.add_argument("--project", required=False, default=PROJECT)
+    parser.add_argument("--owner", required=True)
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--secret-name", "-s")
+    parser.add_argument("--secret-value", "-v")
+    parser.add_argument("--list", "-l", action="store_true")
+    parser.add_argument("--delete", "-d")
+
+    args = parser.parse_args()
+
+    secrets = Secrets(args.owner, args.title, args.project)
+    if args.secret_name and args.secret_value:
+        print(secrets.set_secret(args.secret_name, args.secret_value))
+    elif args.secret_name:
+        print(secrets.get_secret(args.secret_name))
+    elif args.delete:
+        print(secrets.delete_secret(args.delete))
+
+    if args.list:
+        print(json.dumps(secrets.list_secrets(), indent=2))

--- a/cs_publish/utils.py
+++ b/cs_publish/utils.py
@@ -1,0 +1,16 @@
+import re
+import subprocess
+import time
+
+
+def clean(word):
+    return re.sub("[^0-9a-zA-Z]+", "", word).lower()
+
+
+def run(cmd):
+    print(f"Running: {cmd}\n")
+    s = time.time()
+    res = subprocess.run(cmd, shell=True, check=True)
+    f = time.time()
+    print(f"\n\tFinished in {f-s} seconds.\n")
+    return res

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,12 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=["celery", "redis", "gitpython", "pyyaml"],
     include_package_data=True,
-    entry_points={"console_scripts": ["cs-publish=cs_publish.publish:main"]},
+    entry_points={
+        "console_scripts": [
+            "cs-publish=cs_publish.publish:main",
+            "cs-secrets=cs_publish.secrets:main",
+        ]
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU Affero General Public License v3",

--- a/templates/secret.template.yaml
+++ b/templates/secret.template.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name:
+type: Opaque
+stringData: {}


### PR DESCRIPTION
This PR adds a secrets module and command-line tool for handling model-level secrets. Currently, this only works with [GCP Secrets Manager](https://cloud.google.com/secret-manager), but I tried to abstract away the details of working with the GCP API so that the API could be implemented with other managers. For example, it would be helpful to support something like [Bitwarden](https://help.bitwarden.com/article/cli/) to make local development easier.

This PR also (finally) moves all secrets handling to Kubernetes secrets, and it makes the output from `cs-publish --make-config` pipe-able so that updates can be done like this:

```bash
$ cs-publish \
     --models PSLmodels/Tax-Brain \
     --project=cs-workers-dev \
     --tag test \
     --make-config \
     -o - | kubectl apply --dry-run=client -f -
secret/pslmodels-taxbrain-secret created (dry run)
deployment.apps/pslmodels-taxbrain-io created (dry run)
deployment.apps/pslmodels-taxbrain-sim created (dry run)
```
 

And, here's some example usage of the secrets cli:

```bash

$ cs-secrets --owner PSLmodels --title Tax-Cruncher --list
{}
$ cs-secrets --owner PSLmodels --title Tax-Cruncher --secret-name test --secret-value 123
$ cs-secrets --owner PSLmodels --title Tax-Cruncher --secret-name test2 --secret-value abcd
$ cs-secrets --owner PSLmodels --title Tax-Cruncher --list
{
  "test": "123",
  "test2": "abcd"
}
$ cs-secrets --owner PSLmodels --title Tax-Cruncher --secret-name test2
abcd
$ cs-secrets --owner PSLmodels --title Tax-Cruncher --delete test2
$ cs-secrets --owner PSLmodels --title Tax-Cruncher --list
{
  "test": "123"
}


```

(I'll test this PR on GCP when I have time to spin up servers, etc.)