### PR TITLE
Add cli to automate process of modifying config files and pushing to gh

### DIFF
--- a/cs_publish.py
+++ b/cs_publish.py
@@ -1,0 +1,84 @@
+import argparse
+import datetime
+import os
+from pathlib import Path
+import random
+import shutil
+import subprocess
+import tempfile
+import time
+
+import httpx
+import yaml
+
+GH_PRS = "https://api.github.com/repos/compute-tooling/compute-studio-publish/pulls?state=open"
+
+
+def run(cmd):
+    print(f"Running: {cmd}\n")
+    s = time.time()
+    res = subprocess.run(cmd, shell=True, check=True)
+    f = time.time()
+    print(f"\n\tFinished in {f-s} seconds.\n")
+    return res
+
+
+def open_pr_ref(owner, title):
+    resp = httpx.get(GH_PRS)
+    assert resp.status_code == 200, f"Got code: {resp.status_code}"
+    for pr in resp.json():
+        if pr["title"] == f"{owner}/{title}":
+            return pr["head"]["ref"]
+    return None
+
+
+def pub(args):
+    start = os.path.abspath(Path("."))
+    try:
+        with tempfile.TemporaryDirectory(prefix="update-") as td:
+            run(
+                f"git clone git@github.com:compute-tooling/compute-studio-publish.git {td}"
+            )
+            os.chdir(Path(td))
+            o, t = args.name.split("/")
+
+            now = datetime.datetime.now()
+
+            ref = open_pr_ref(o, t)
+            if ref is not None:
+                run(f"git fetch origin {ref} && git checkout {ref}")
+                create = False
+            else:
+                ref = (
+                    "update-"
+                    + str(now.strftime("%Y-%m-%d"))
+                    + random.randint(1111, 9999)
+                )
+                run(f"git checkout -b {ref}")
+                create = True
+
+            config_file_path = Path("config") / o / f"{t}.yaml"
+            with open(config_file_path, "w") as f:
+                f.write(yaml.dump({"owner": o, "title": t, "timestamp": str(now)}))
+
+            commit_message = f"Update {o}/{t} - {str(now)}"
+            if args.skip_test:
+                commit_message = f"[skip test] {commit_message}"
+            run(f"git add -u && git commit -m '{commit_message}'")
+
+            # same for now
+            if create:
+                run(f"git push origin {ref}")
+            else:
+                run(f"git push origin {ref}")
+    finally:
+        os.chdir(start)
+
+
+def cli():
+    parser = argparse.ArgumentParser("Modify model config file and open GH PR.")
+    parser.add_argument("--name", "-n", required=True)
+    parser.add_argument("--skip-test", action="store_true")
+    parser.set_defaults(func=pub)
+    args = parser.parse_args()
+    args.func(args)

--- a/cs_publish.py
+++ b/cs_publish.py
@@ -3,7 +3,6 @@ import datetime
 import os
 from pathlib import Path
 import random
-import shutil
 import subprocess
 import tempfile
 import time

--- a/setup.py
+++ b/setup.py
@@ -13,18 +13,16 @@ setuptools.setup(
     version=os.environ.get("TAG", "0.0.0"),
     author="Hank Doupe",
     author_email="hank@compute.studio",
-    description=("Build, publish, and run Compute Studio workers."),
+    description=("Create and update C/S Publish PRs."),
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/compute-tooling/compute-studio-workers",
     packages=setuptools.find_packages(),
-    install_requires=["celery", "redis", "gitpython", "pyyaml"],
+    install_requires=["pyyaml", "httpx"],
     include_package_data=True,
     entry_points={
         "console_scripts": [
-            "cs-publish=cs_publish.client.publish:main",
-            "cs-secrets=cs_publish.client.secrets:main",
-            "cs-job=cs_publish.executors.kubernetes:main",
+            "cs-publish=cs_publish:cli",
         ]
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     description=("Create and update C/S Publish PRs."),
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/compute-tooling/compute-studio-workers",
+    url="https://github.com/compute-tooling/compute-studio-publish",
     packages=setuptools.find_packages(),
     install_requires=["pyyaml", "httpx"],
     include_package_data=True,


### PR DESCRIPTION
This is helpful for me to run just from my desktop to automate these updates. It seems like there isn't a good way to open PR's in an automated fashion without a "GitHub App". I'll look into doing this at a later date. For now, I can create new branches or updating existing ones with this command:

```
cs-publish -n PSLmodels/Tax-Cruncher
```

Or to skip tests:

```
cs-publish -n PSLmodels/OG-USA --skip-test
```